### PR TITLE
update rosinstall

### DIFF
--- a/moveit.rosinstall
+++ b/moveit.rosinstall
@@ -11,7 +11,7 @@
 - git:
     local-name: geometric_shapes
     uri: https://github.com/ros-planning/geometric_shapes.git
-    version: melodic-devel
+    version: noetic-devel
 - git:
     local-name: moveit
     uri: https://github.com/ros-planning/moveit.git


### PR DESCRIPTION
Changed to use `noetic-devel` because the build did not pass with `melodic-devel`

