### PR TITLE
uniform clang-format version

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -16,6 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Install clang-format-12
-      run: sudo apt-get install clang-format-12
+    - name: Install clang-format-14
+      run: sudo apt-get install clang-format-14
     - uses: pre-commit/action@v3.0.0


### PR DESCRIPTION
format.yaml and pre-commit-config.yaml use different version of clang-format (12 and 14)

set clang-format into format.yaml to version 14